### PR TITLE
Update browser.js

### DIFF
--- a/lib/browser.js
+++ b/lib/browser.js
@@ -45,7 +45,7 @@ var round = function(n){
 var compute = global.getComputedStyle ? function(node){
     var cts = getComputedStyle(node, null)
     return function(property){
-        return cts ? cts.getPropertyValue(hyphenate(property)) : ""
+        return cts && cts.getPropertyValue(hyphenate(property)) ? cts.getPropertyValue(hyphenate(property)) : ""
     }
 } : /*(css3)?*/function(node){
     var cts = node.currentStyle


### PR DESCRIPTION
Its a extrem silly bug. At some Android Versions i get an error: "Cannot call method 'replace' of null". 

I get the error on my application with several thousand users a day, only at a handful of android devices.

like: browser - Mozilla/5.0 (Linux; U; Android 4.3; de-de; GT-I9300 Build/JSS15J) AppleWebKit/534.30 (KHTML, like Gecko) Version/4.0 Mobile Safari/534.30

The main error are on line 841 at moofx.js. 
properties = (rules(transitionName + "Property").replace(/\s+/g, "")

that fix works for me, unfortunately I can not assess whether this fix has any impacts. for me all runs fine :-) if you want you can include this fix
